### PR TITLE
explicit birthdate input to be type text

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ Caso você faça o _download_ de bibliotecas externas, utilize o diretório _lib
   Pontos importantes:
   * Um rótulo abaixo do campo nova senha com o id label-birthdate e o texto "Data de nascimento"
   * O campo deve ter o atributo name com o valor "birthdate"
+  * O campo deve ser do tipo "text"
   * O campo deve ter um placeholder com o valor "dd/mm/aaaa"
   * Posicione esse campo abaixo do rótulo
 


### PR DESCRIPTION
Não ficou explícito que esse input deveria ser type=text , o que fez alguns alunos tentarem exaustivamente usar o type=date  para informar a data de nascimento. 

O problema foi que o teste do Cypress digita uma data no formato brasileiro nesse input, coisa que faz o CyPress lançar um erro, se for type=date , aceitando apenas datas no formato americano. 

O log do evaluator mostra esse erro mas os estudantes não conseguem interpretar.